### PR TITLE
Prevent importing from /src in dsc modules (BDWEB1-1740)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tslint-config-dollarshaveclub",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "tslint configuration for Dollar Shave Club",
   "main": "tslint.js",
   "scripts": {
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/dollarshaveclub/tslint-config-dollarshaveclub#readme",
   "dependencies": {
-    "tslint": "^5.8.0",
+    "tslint": "^5.16.0",
     "tslint-config-standard": "^8.0.0",
     "tslint-react": "^3.3.3"
   },

--- a/react.js
+++ b/react.js
@@ -5,5 +5,10 @@ module.exports = {
   rules: {
     'jsx-no-lambda': false,
     'jsx-no-multiline-js': false,
+    'import-blacklist': [
+      true,
+      ['^@dollarshaveclub/.*/src/.*'], // prevent importing from src
+
+    ],
   },
 }

--- a/tslint.js
+++ b/tslint.js
@@ -7,5 +7,10 @@ module.exports = {
     'no-empty': false,
     'no-floating-promises': false,
     'trailing-comma': [true, { multiline: 'always', singleline: 'never' }],
+    'import-blacklist': [
+      true,
+      ['^@dollarshaveclub/.*/src/.*'], // prevent importing from src
+
+    ],
   },
 }


### PR DESCRIPTION
What changed? 
Prevent imports from `@dollarshaveclub/repo/src/module`.  Instead, users should import from `@dollarshaveclub/repo/dist/module`or `@dollarshaveclub/repo/module`.

Are there gotchas?
?
